### PR TITLE
Update spectrum.js

### DIFF
--- a/assets/js/spectrum.js
+++ b/assets/js/spectrum.js
@@ -53,8 +53,8 @@
             return contains(style.backgroundColor, 'rgba') || contains(style.backgroundColor, 'hsla');
         })(),
         inputTypeColorSupport = (function () {
-            var colorInput = $("<input type='color' value='!' />")[0];
-            return colorInput.type === "color" && colorInput.value !== "!";
+            var colorInput = $("<input type='color' value='#ffffff' />")[0];
+            return colorInput.type === "color" && colorInput.value !== "#ffffff";
         })(),
         replaceInput = [
             "<div class='sp-replacer'>",


### PR DESCRIPTION
Fixes jQuery 2.1.4 warning message:

`The specified value '!' does not conform to the required format`

It's not major, obviously. I don't know if ! has any special meaning. And I didn't update spectrum.min.js because I don't know what your build process is for that.

Great plugin, by the way. Thanks for sharing it.