### PR TITLE
Fixes #43, translations cannot be found

### DIFF
--- a/src/ColorInput.php
+++ b/src/ColorInput.php
@@ -27,6 +27,11 @@ use kartik\base\TranslationTrait;
  */
 class ColorInput extends Html5Input
 {
+    /*
+     * @inheritdoc
+     */
+    public $sourcePath = '@vendor/kartik-v/yii2-krajee-base/src';
+    
     /**
      * @var boolean whether to use the native HTML5 color input
      */


### PR DESCRIPTION
Fixing issue that translation files can not be found because of https://github.com/kartik-v/yii2-krajee-base version 3.0.5 
caused by https://github.com/kartik-v/yii2-krajee-base/issues/119
https://github.com/kartik-v/yii2-krajee-base/commit/127f3508f98f9ad3188ebb9305ad12fe03144416